### PR TITLE
Fix extrude

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,6 +31,7 @@ julia = "1.6"
 [extras]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [targets]
-test = ["CUDA", "Test"]
+test = ["CUDA", "Test", "Random"]

--- a/src/ParametricBodies.jl
+++ b/src/ParametricBodies.jl
@@ -1,6 +1,29 @@
 module ParametricBodies
 
 using StaticArrays,ForwardDiff
+# Non-allocating method for 2x3 SMatrix solve
+using LinearAlgebra
+import Base: \
+@inline function (\)(a::SMatrix{2,3}, b::SVector{2})
+    # columns of a'
+    a1,a2 = a[1,:],a[2,:]
+    
+    # Q,R decomposition
+    r11 = norm(a1)
+    q1 = a1/r11
+    r12 = q1'*a2
+    p = a2-r12*q1
+    r22 = norm(p) < eps(r11) ? one(r11) : norm(p)
+    q2 = p/r22
+
+    # forward substitution to solve v = R'\b
+    v1 = b[1]/r11
+    v2 = (b[2]-r12*v1)/r22
+
+    # return solution x = Qv 
+    return q1*v1+q2*v2
+end
+
 import WaterLily: AbstractBody,measure,sdf,interp
 
 abstract type AbstractParametricBody <: AbstractBody end
@@ -78,7 +101,7 @@ function curve_props(body::ParametricBody,x,t;fastd²=Inf)
     ξ = body.map(x,t)
     if isfinite(fastd²) && applicable(body.locate,ξ,t,true)
         d = body.scale*body.locate(ξ,t,true)-body.half_thk
-        d^2>fastd² && return d,zero(x),zero(x)
+        d^2>fastd² && return d,zero(ξ),zero(ξ)
     end
 
     # Locate nearest u, and get vector

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,7 +60,7 @@ end
 
     
     x = SA_F32[1 0 0; 0 1 0]\SA_F32[0,1]
-    @test @allocated(SA_F32[1 0 0; 0 1 0]\SA_F32[0,1]) <305
+    @test @allocated(SA_F32[1 0 0; 0 1 0]\SA_F32[0,1]) <400
 end
 
 @testset "HashedLocators.jl" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,28 @@ using CUDA
     @test all(measure(body3,SA[1.,0.,1.],0.,fastd²=1) .≈ (1,[0,0,1],[0,0,0]))
 end
 
+@testset "SMatrix 2x3" begin
+    using Random,LinearAlgebra
+    Random.seed!(123)
+    for i in 1:10
+        a = @SMatrix randn(2, 3)
+        b = @SVector randn(2)
+        @test Matrix(a)\b ≈ a\b
+    end
+
+    a = SA[1.0 1e-10 0.0; 0.0 1.0 1e-10]
+    b = SA[1.,1.]
+    @test Matrix(a)\b ≈ a\b
+
+    a = SA[1.0 2.0 3.0; 2.0 4.0 6.0]
+    b = SA[7.0, 14.0]
+    @test Matrix(a)\b ≈ a\b
+
+    
+    x = SA_F32[1 0 0; 0 1 0]\SA_F32[0,1]
+    @test @allocated(SA_F32[1 0 0; 0 1 0]\SA_F32[0,1]) <305
+end
+
 @testset "HashedLocators.jl" begin
     curve(θ,t) = SA[cos(θ+t),sin(θ+t)]
     locator = HashedLocator(curve,(0.,2π),T=Float32)
@@ -222,6 +244,15 @@ end
     map(x::SVector{3},t) = SA[x[1],√(x[2]^2+x[3]^2)]
     sphere = ParametricBody(circle;map,scale=1f0)
     @test [measure(sphere,SA[2,3,6],0)...] ≈ [0,[2,3,6]./7,[0,0,0]] atol=1e-4
+
+    # Check GPU
+    if CUDA.functional()
+        t = CUDA.zeros(2)
+        x = [SA_F32[2,3,6],SA_F32[0,3,0]] |> CuArray
+        a,b = measure.(Ref(sphere),x,t) |> Array
+        @test [a...] ≈ [0,[2,3,6]./7,[0,0,0]] atol=1e-4
+        @test all(b .≈ (-4,[0,1,0],[0,0,0]))
+    end
 end
 @testset "PlanarBodies.jl" begin
     T = Float32


### PR DESCRIPTION
This PR enables extruded geometry mappings on GPUs.
1. The `fastd²` version of curve_props now returns the correct length normal and velocity zero vectors.
2. The `\` operator now uses a special non-allocating method for `a=SMatrix{2,3}`. I added a test set for this and will put together a PR for StaticArrays.