### PR TITLE
Lots of little fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,8 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 WaterLily = "ed894a53-35f9-47f1-b17f-85db9237eebd"
 
 [weakdeps]
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [compat]
 Adapt = "4.0"
@@ -24,14 +24,14 @@ FastGaussQuadrature = "1.0"
 ForwardDiff = "^0.10.18"
 KernelAbstractions = "^0.9.1"
 RecipesBase = "1.3"
-WaterLily = "1.2"
 StaticArrays = "^1.1.0"
+WaterLily = "1.4.0"
 julia = "1.6"
 
 [extras]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["CUDA", "Test", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ ForwardDiff = "^0.10.18"
 KernelAbstractions = "^0.9.1"
 RecipesBase = "1.3"
 StaticArrays = "^1.1.0"
-WaterLily = "1.4.0"
+WaterLily = "1.4.1"
 julia = "1.6"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -62,7 +62,12 @@ pnts = SA[0. 3. -1. -4  -4.
 nurbs = interpNurbs(pnts;p=3) # fit a cubic NurbsCurve through the points
 body = ParametricBody(nurbs)
 ```
-An efficient and accurate `NurbsLocator` is created automatically for `NurbsCurve`s. However, it is not as fast as a `HashedLocator`. If speed is a limiting factor, you can always use `body = HashedBody(nurbs,(0,1))` to create a fast locator, although it may not be as accurate.
+An efficient and accurate `NurbsLocator` is created automatically for `NurbsCurve`s. This should be prefered over `HashedLocator(nurbs,(0,1))`, especially for `degree=1` splines featuring sharp corners.
+```julia
+M = BSplineCurve(SA_F32[1 1 0 -1 -1;0 1 1/2 1 0];degree=1) # Make Linear B-Spline
+letter = ParametricBody(M,thk=2,boundary=false)            # Automatically makes a NURBSLocator
+# Don't use HashedBody(M,(0,1),step=0.1,thk=2,boundary=false)
+```
 
 You can also create a NURBS by supplying the control points, knots and weights directly. For example, the code below defines a 3D torus using a NURBS to describe the major circle of radius 7, and thickening the space-curve with a minor radius of 1.
 ```julia

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ sim = arc_sim();
 ```
 See the WaterLily repo and the video above for more discussion of this primary use of the map function. 
 
-A secondary application of the mapping function for `ParametricBodies` is to map from a 3D x-space to a 2D ξ-space, effectively extruding a 2D parametric curve into a 3D surface. For example, we can make a cylinder or sphere starting from a 2D NURBS circle using
+A secondary application of the mapping function for `ParametricBodies` is to map from a 3D x-space to a 2D ξ-space, effectively "sweeping" a 2D parametric curve into a 3D surface. For example, we can make a cylinder or sphere starting from a 2D NURBS circle using
 ```julia
 cps = SA_32[7 7 0 -7 -7 -7  0  7 7
             0 7 7  7  0 -7 -7 -7 0] # a 2D circle
@@ -104,12 +104,12 @@ knots = SA_32[0,0,0,1/4,1/4,1/2,1/2,3/4,3/4,1,1,1]  # non-uniform knot and weigh
 circle = NurbsCurve(cps,knots,weights)
 
 # Make a cylinder
-map(x::SVector{3},t) = SA[x[2],x[3]] # extrude along x[1]-axis
-cylinder = ParametricBody(circle;map,ndims=3)  
+extrude(x::SVector{3},t) = SA[x[2],x[3]] # extrude along x[1]-axis
+cylinder = ParametricBody(circle;map=extrude,ndims=3)  
 
 # Make a sphere
-map(x::SVector{3},t) = SA[x[1],hypot(x[2],x[3])] # revolve around x[1]-axis
-sphere = ParametricBody(circle;map,ndims=3)
+revolve(x::SVector{3},t) = SA[x[1],hypot(x[2],x[3])] # revolve around x[1]-axis
+sphere = ParametricBody(circle;map=revolve,ndims=3)
 ```
 and if we started from, say, a NACA profile, the same technique could make a prismatic wing or a 3D air-ship hull. Note that the `ndims` argument must be explicitly supplied to let `ParametricBodies` know that `map(x)` uses a 3D input vector.
 

--- a/src/HashedLocators.jl
+++ b/src/HashedLocators.jl
@@ -45,8 +45,7 @@ function HashedLocator(curve,lims;t⁰=0,step=1,buffer=2,T=Float32,mem=Array,kwa
     # Apply type and get refinement function
     lims,t⁰,step = T.(lims),T(t⁰),T(step)
     closed = curve(first(lims),t⁰)≈curve(last(lims),t⁰)
-    du(u) = ForwardDiff.derivative(u->curve(u,t⁰),u)
-    f = refine(curve,lims,closed && du(first(lims))≈du(last(lims)))
+    f = refine(curve,lims,closed && tangent(curve,first(lims),t⁰)≈tangent(curve,last(lims),t⁰))
 
     # Get curve's bounding box
     samples = range(lims...,64)
@@ -68,8 +67,7 @@ end
 @inline mymod(x,low,high) = low+mod(x-low,high-low)
 function refine(curve,lims,closed)::Function
     # uv⁺ = argmin_uv (X-curve(uv,t))² -> alignment(X,uv⁺,t))=0
-    dcurve(uv,t) = ForwardDiff.derivative(uv->curve(uv,t),uv)
-    align(X,uv,t) = (X-curve(uv,t))'*dcurve(uv,t)
+    align(X,uv,t) = (X-curve(uv,t))'*tangent(curve,uv,t)
     dalign(X,uv,t) = ForwardDiff.derivative(uv->align(X,uv,t),uv)
     mx = (lims[2]-lims[1])/25; mn = mx/100
     return function(X,uv::T,t) where T # step to alignment root

--- a/src/NurbsLocator.jl
+++ b/src/NurbsLocator.jl
@@ -14,10 +14,10 @@ end
 function NurbsLocator(curve::NurbsCurve)
     low,high = first(curve.knots),last(curve.knots)
     dc(u) = ForwardDiff.derivative(curve,u)
-    NurbsLocator(curve,curve(low)≈curve(high) && dc(low)≈dc(high), # closed C¹ curve?
-        refine(curve,(low,high),curve(low)≈curve(high)))     # Newton step refinement
+    C¹end = curve(low)≈curve(high) && dc(low)≈dc(high) # closed C¹ curve?
+    NurbsLocator(curve,C¹end,refine(curve,(low,high),C¹end))
 end
-Adapt.adapt_structure(to, x::NurbsLocator) = NurbsLocator(x.curve,x.C¹end,x.C,x.R)
+Adapt.adapt_structure(to, x::NurbsLocator) = NurbsLocator(x.curve,x.C¹end,x.refine)
 
 update!(l::NurbsLocator,curve,t) = l=NurbsLocator(curve) # just make a new locator
 
@@ -27,6 +27,11 @@ function notC¹(l::NurbsLocator{C},uv) where C<:NurbsCurve{n,d} where {n,d}
     low,high = first(l.curve.knots),last(l.curve.knots)
     (uv≈low || uv≈high) ? !l.C¹end : false 
 end
+function eachside(l::NurbsLocator,uv,s=√eps(typeof(uv)))
+    low,high = first(l.curve.knots),last(l.curve.knots)
+    l.curve.pnts[:,1] ≈ l.curve.pnts[:,end] ? mymod.(uv .+(-s,s),low,high) : clamp.(uv .+(-s,s),low,high)
+end
+
 """
     (l::NurbsLocator)(x,t)
 

--- a/src/NurbsLocator.jl
+++ b/src/NurbsLocator.jl
@@ -13,8 +13,7 @@ end
 
 function NurbsLocator(curve::NurbsCurve)
     low,high = first(curve.knots),last(curve.knots)
-    dc(u) = ForwardDiff.derivative(curve,u)
-    C¹end = curve(low)≈curve(high) && dc(low)≈dc(high) # closed C¹ curve?
+    C¹end = curve(low)≈curve(high) && tangent(curve,low,0)≈tangent(curve,high,0) # closed C¹ curve?
     NurbsLocator(curve,C¹end,refine(curve,(low,high),C¹end))
 end
 Adapt.adapt_structure(to, x::NurbsLocator) = NurbsLocator(x.curve,x.C¹end,x.refine)

--- a/src/NurbsLocator.jl
+++ b/src/NurbsLocator.jl
@@ -38,12 +38,13 @@ Estimate the parameter value `u⁺ = argmin_u (x-l.curve(u))²` for a NURBS in t
 1. The nearest point `u` on the `degree=1` version of the curve is found. Return `u⁺=u` if `fast`.
 2. `refine` this guess until the change in `u` is negligible. 
 """
-function (l::NurbsLocator{C})(x,t) where C<:NurbsCurve{n,degree} where {n,degree}
-    uv = lin_loc(l,x)
-    degree == 1 && return uv
-    for _ in 1:5
-        uv,done = l.refine(x,uv,t); done && break
-    end; uv
+function (l::NurbsLocator{C})(x,t,fastd²=Inf) where C<:NurbsCurve{n,degree} where {n,degree}
+    u = lin_loc(l,x)
+    degree == 1 && return u
+    for i in 4:-1:0
+        u,done = l.refine(x,u,t)
+        (done || isfinite(fastd²) && sum(abs2,l.curve(u)-x)≥1.4f0^i*fastd²) && break
+    end; u
 end
 function lin_loc(l::NurbsLocator,x)
     pnts = l.curve.pnts; n = size(pnts,2)-1

--- a/src/NurbsLocator.jl
+++ b/src/NurbsLocator.jl
@@ -38,10 +38,9 @@ Estimate the parameter value `u⁺ = argmin_u (x-l.curve(u))²` for a NURBS in t
 1. The nearest point `u` on the `degree=1` version of the curve is found. Return `u⁺=u` if `fast`.
 2. `refine` this guess until the change in `u` is negligible. 
 """
-function (l::NurbsLocator{C})(x,t,fast=false) where C<:NurbsCurve{n,degree} where {n,degree}
-    uv,fuv = lin_loc(l,x)
+function (l::NurbsLocator{C})(x,t) where C<:NurbsCurve{n,degree} where {n,degree}
+    uv = lin_loc(l,x)
     degree == 1 && return uv
-    fast && return √fuv
     for _ in 1:5
         uv,done = l.refine(x,uv,t); done && break
     end; uv
@@ -56,7 +55,7 @@ function lin_loc(l::NurbsLocator,x)
         p = clamp(((x-a)'*s)/(s'*s),0,1)       # perp distance along s
         uᵢ = (x=(i-1+p)/n,f=sum(abs2,x-a-s*p)) # segment minimizer
         uᵢ.f<u.f && (u=uᵢ) # Replace current best
-    end; u
+    end; u.x
 end
 """
     ParametricBody(curve::NurbsCurve;kwargs...)

--- a/src/ParametricBodies.jl
+++ b/src/ParametricBodies.jl
@@ -99,10 +99,10 @@ ParametricBody(curve,locate;dotS=get_dotS(curve),thk=0f0,boundary=true,map=dmap,
 function curve_props(body::ParametricBody,x,t;fastd²=Inf)
     # Map x to ξ and do fast bounding box check
     ξ = body.map(x,t)
-    if isfinite(fastd²) && applicable(body.locate,ξ,t,true)
-        d = body.scale*body.locate(ξ,t,true)-body.half_thk
-        d^2>fastd² && return d,zero(ξ),zero(ξ)
-    end
+    # if isfinite(fastd²) && applicable(body.locate,ξ,t,true)
+    #     d = body.scale*body.locate(ξ,t,true)-body.half_thk
+    #     d^2>fastd² && return d,zero(ξ),zero(ξ)
+    # end
 
     # Locate nearest u, and get vector
     u = body.locate(ξ,t)

--- a/src/ParametricBodies.jl
+++ b/src/ParametricBodies.jl
@@ -111,13 +111,13 @@ function curve_props(body::ParametricBody,x,t;fastd²=Inf)
     # Get unit normal
     n = if body.boundary # has signed normal
         if C¹(body.locate,u)
-            perp(tangent(body.curve,u,t)) # easy peasy
+            perp(hat(tangent(body.curve,u,t))) # easy peasy
         else # not so easy...
             s = sum(tangent.(body.curve,eachside(body.locate,u),t)) # corner average tangent
             sign(perp(s)'p)*hat(p)                                  # signed corner-normal
         end
     else # unsigned normal towards p
-        notC¹(body.locate,u) ? hat(p) : align(p,tangent(body.curve,u,t))
+        notC¹(body.locate,u) ? hat(p) : align(p,hat(tangent(body.curve,u,t)))
     end
     
     # Get scaled & thinkess adjusted distance and dot(S)
@@ -126,7 +126,7 @@ end
 notC¹(::Function,u) = false; C¹(f,u) = !notC¹(f,u)
 
 hat(p) = p/√(eps(eltype(p))+p'*p)
-tangent(curve,u,t) = hat(ForwardDiff.derivative(u->curve(u,t),u))
+tangent(curve,u,t) = ForwardDiff.derivative(u->curve(u,t),u)
 align(p,s) = hat(p-(p'*s)*s)
 perp(s::SVector{2}) = SA[s[2],-s[1]]
 perp(s) = s # should never be used!

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -221,6 +221,23 @@ end
         @test all(a .≈ (1,[0,0,1],[0,0,0]))
         @test all(b .≈ (5√2-6,[√2/2,√2/2,0],[0,0,0]))
     end
+
+    # Check (non)convex corners
+    e = √eps(Float32)
+    openM = ParametricBody(BSplineCurve(SA_F32[1 1 0 -1 -1;0 1 1/2 1 0],degree=1))
+    @test [measure(openM,SA[1-e,-1],0f0)...]≈[-1,[0,1],[0,0]] # just inside end-point
+    @test [measure(openM,SA[1+e,-1],0f0)...]≈[ 1,[0,-1],[0,0]] # just outside end-point
+    @test [measure(openM,SA[0,e],0f0)...]≈[-0.5,[0,1],[0,0]] # inside concave corner
+    @test [measure(openM,SA[2+e,2],0f0)...]≈[√2,[√2/2,√2/2],[0,0]] # outside convex corner
+    hashM = HashedBody(BSplineCurve(SA_F32[1 1 0 -1 -1;0 1 1/2 1 0],degree=1),(0,1),step=0.1) # doesn't know where knots are!
+    @test [measure(hashM,SA[1-e,-1],0f0)...]≈[-1,[0,1],[0,0]] # end-point still works
+    @test [measure(hashM,SA[2+e,2],0f0)...]≈[√2,[√2/2,√2/2],[0,0]] broken = true # "internal" corners may not!!
+    closedM = ParametricBody(BSplineCurve(SA_F32[-1 1 1 0 -1 -1;0 0 1 1/2 1 0],degree=1))
+    @test [measure(closedM,SA[-2-e,-1],0f0)...]≈[√2,[-√2/2,-√2/2],[0,0]] # outside end-point corner
+    closedM2 = ParametricBody(BSplineCurve(SA_F32[-1 1 1 0 -1 -1;0 0 1 1/2 1 0],degree=2)) # still has C⁰ end
+    @test [measure(closedM2,SA[-2-e,-1],0f0)...]≈[√2,[-√2/2,-√2/2],[0,0]] # outside end-point corner
+    closedM3 = ParametricBody(BSplineCurve(SA_F32[0 1 1 0 -1 -1 0;0 0 1 1/2 1 0 0],degree=2)) # C¹ end
+    @test [measure(closedM3,SA[-e,-1],0f0)...]≈[1,[0,-1],[0,0]] # outside end-point corner
 end
 @testset "Extruded Bodies" begin
     circle = nurbs_circle(Float32,7)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,8 +107,7 @@ end
     @test [measure(body,SA[-0.3,-0.4],0.)...] ≈ [-0.5,[-3/5,-4/5],[4/5,-3/5]] rtol=1e-4
 
     # model arc as space-curve with finite thickness
-    thk = 0.2
-    body = HashedBody(curve,(0.,π/2);step,buffer,T=Float64,thk,boundary=false)
+    body = HashedBody(curve,(0.,π/2);step=0.2,buffer=1,T=Float64,thk=0.2,boundary=false)
     @test [measure(body,SA[0.7,-0.4],0.)...] ≈ [0.4,[-3/5,-4/5],[0,1]] rtol=1e-4
     @test measure(body,SA[0.4,0.3],0.)[2] ≈ [-4/5,-3/5] rtol=1e-4
 end
@@ -157,7 +156,7 @@ end
 
     # Wrap the shape function inside the parametric body class and check measurements
     body = HashedBody(circle, (0,1));
-    @test [measure(body,SA[-6,0],0)...] ≈ [1,[-1,0],[0,0]]
+    @test [measure(body,SA[-6,0],0)...] ≈ [1,[-1,0],[0,0]] rtol=1e-6
     @test [measure(body,SA[ 5,5],0)...] ≈ [5√2-5,[ √2/2,√2/2],[0,0]] rtol=1e-6
     @test [measure(body,SA[-5,5],0)...] ≈ [5√2-5,[-√2/2,√2/2],[0,0]] rtol=1e-6
 
@@ -170,11 +169,6 @@ end
     @test all(reduce(hcat,nurbs.(s,0.0)).-pnts.<10eps(eltype(pnts)))
 end
 @testset "NurbsLocator.jl" begin
-    # Check davidon minimizer
-    @test davidon(x->(x+3)*(x-1)^2,-2.,2.) ≈ 1
-    @test davidon(x->-log(x)/x,1.,10.) ≈ exp(1)
-    @test davidon(x->cos(x)+cos(3x)/3,0.,1.75π) ≈ π
-
     # define a circle
     T = Float32
     circle = nurbs_circle(T)
@@ -193,10 +187,6 @@ end
         u = locate.(x,t)
         @test u|>Array ≈ [1/8,1/4]
     end
-
-    # Test fast measure
-    @test locate.C≈[0,0]
-    @test locate.R≈[5,5]
 
     @test [measure(body,SA[5,5],0,fastd²=2)...]≈[5√2-5,[0,0],[0,0]] rtol=1e-6 # inside BBox but outside d²
     @test [measure(body,SA[6,8],0,fastd²=2)...]≈[√10,[0,0],[0,0]] rtol=1e-6   # outside BBox (bounded d²)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -137,9 +137,8 @@ end
     @test all([cross(square(s,0.),square(s+0.1,0.))>0 for s in range(0,.9,10)])
 
     # check derivatives
-    dcurve(u) = ForwardDiff.derivative(u->square(u,0),u)
-    @test dcurve(0f0) ≈ [0,40]
-    @test dcurve(0.5f0) ≈ [0,-40]
+    @test ParametricBodies.tangent(square,0f0,0) ≈ [0,40]
+    @test ParametricBodies.tangent(square,0.5f0,0) ≈ [0,-40]
 
     # Wrap the shape function inside the parametric body class and check measurements
     body = HashedBody(square, (0,1));

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -188,8 +188,9 @@ end
     end
 
     @test [measure(body,SA[5,5],0,fastd²=2)...]≈[5√2-5,[0,0],[0,0]] rtol=1e-6 # inside BBox but outside d²
-    @test [measure(body,SA[6,8],0,fastd²=2)...]≈[√10,[0,0],[0,0]] rtol=1e-6 broken=true  # outside BBox (bounded d²)
+    @test [measure(body,SA[6,8],0,fastd²=2)...]≈[5,[0,0],[0,0]] rtol=1e-6     # outside BBox & d² but still good
     @test [measure(body,SA[6,0],0,fastd²=2)...]≈[1,[1,0],[0,0]] rtol=1e-6     # outside BBox but inside d²
+    @test [measure(body,SA[0.75,1],0,fastd²=2)...]≈[-3.75,[0,0],[0,0]] rtol=1e-1 # outside d² but correct sign
 
     # Check DynamicNurbsBody
     body = DynamicNurbsBody(circle)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,17 +238,17 @@ end
     closedM3 = ParametricBody(BSplineCurve(SA_F32[0 1 1 0 -1 -1 0;0 0 1 1/2 1 0 0],degree=2)) # C¹ end
     @test [measure(closedM3,SA[-e,-1],0f0)...]≈[1,[0,-1],[0,0]] # outside end-point corner
 end
-@testset "Extruded Bodies" begin
+@testset "Swept Bodies" begin
     circle = nurbs_circle(Float32,7)
     
     # Make a cylinder
-    map(x::SVector{3},t) = SA[x[2],x[3]]
-    cylinder = ParametricBody(circle;map,ndims=3)
+    extrude(x::SVector{3},t) = SA[x[2],x[3]]
+    cylinder = ParametricBody(circle;map=extrude,ndims=3)
     @test [measure(cylinder,SA[2,3,6],0)...] ≈ [√45-7,[0,3,6]./√45,[0,0,0]] atol=1e-4
 
     # Make a sphere
-    map(x::SVector{3},t) = SA[x[1],hypot(x[2],x[3])]
-    sphere = ParametricBody(circle;map,ndims=3) # define ndims
+    revolve(x::SVector{3},t) = SA[x[1],hypot(x[2],x[3])]
+    sphere = ParametricBody(circle;map=revolve,ndims=3) # define ndims
     @test [measure(sphere,SA[2,3,6],0)...] ≈ [0,[2,3,6]./7,[0,0,0]] atol=1e-4
 
     # Check GPU


### PR DESCRIPTION
I was trying to improve the `NurbsLocator` and ended up fixing lots of stuff:
1. Fixed `lin_locator` to work regardless of the NURBS degree. This is really fast and gives you an initial `u` guess for any degree without a hash.
2. Fixed `refine` to set a min and max step size, to fallback to gradient decent when outside of a basin, and to only use modular parameterization `mymod(u)` when the curve is closed & C1!
3. `refine` also returns a convergence flag to ensures you don't waste time `refine`ing when you're stuck at an endpoint, or stop too early.
4. Changed `NurbsLocator` to use 1-3 above, completely replacing the inverse interpolator stuff. 
5. Fixed the treatment of `boundary=true` with sharp corners by returning a robust outward facing normal. For C0 points, we now sample on `eachside` of `u` to construct a robust "outward" direction. Then we set `n=sign(d)*hat(p)` such that `d=n'p` has the correct sign.
6. Fixed `fastd²` logic, which was completely wrong before. 
7. Cleaned up pressure and swept geometry tests, and added tests for (non)convex corners.
8. Updated the README